### PR TITLE
feat: add log desensitization configuration

### DIFF
--- a/global/config.go
+++ b/global/config.go
@@ -38,6 +38,7 @@ var (
 	//GCONFIG_RECORD_PATCH_VERSION_LOG   int64 = 20250106 // 日志数据库补丁日期
 	GCONFIG_RECORD_ALL_SRC_BYTE_INFO int64 = 0 //记录原始信息(默认不开启)
 	GCONFIG_ENABLE_HTTP3             int64 = 0 //配置是否启用http3(默认关闭)
+	GCONFIG_RECORD_LOG_DESENSITIZE   int64 = 1 //请求记录是否进行脱敏处理 1开启脱敏 0关闭脱敏
 
 	GCONFIG_RECORD_TOKEN_EXPIRE_MINTUTES     int64 = 5  //令牌有效期 单位分钟
 	GCONFIG_RECORD_ANNOUNCEMENT_EXPIRE_HOURS int64 = 24 //公告有效期 单位小时

--- a/wafenginecore/wafengine.go
+++ b/wafenginecore/wafengine.go
@@ -639,7 +639,7 @@ func (waf *WafEngine) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// 日志保存时候也是脱敏保存防止，数据库密码被破解，遭到敏感信息遭到泄露
-		if weblogbean.BODY != "" {
+		if global.GCONFIG_RECORD_LOG_DESENSITIZE == 1 && weblogbean.BODY != "" {
 			weblogbean.BODY = utils.DeSenTextByCustomMark(enums.DLP_MARK_RULE_LoginSensitiveInfoMaskRule, weblogbean.BODY)
 		}
 		remoteUrl, err := url.Parse(hostTarget.TargetHost)

--- a/waftask/task_config.go
+++ b/waftask/task_config.go
@@ -125,6 +125,8 @@ func setConfigIntValue(name string, value int64, change int) {
 		break
 	case "http3":
 		global.GCONFIG_ENABLE_HTTP3 = value
+	case "record_log_desensitize":
+		global.GCONFIG_RECORD_LOG_DESENSITIZE = value
 	default:
 		zlog.Warn("Unknown config item:", name)
 	}
@@ -276,6 +278,7 @@ func TaskLoadSetting(initLoad bool) {
 	updateConfigIntItem(initLoad, "network", "http3", global.GCONFIG_ENABLE_HTTP3, "是否启用http3（1启用 0关闭）", "int", "", configMap)
 
 	updateConfigIntItem(initLoad, "system", "record_all_src_byte_info", global.GCONFIG_RECORD_ALL_SRC_BYTE_INFO, "启动记录原始请求BODY报文（1启动 0关闭）", "int", "", configMap)
+	updateConfigIntItem(initLoad, "system", "record_log_desensitize", global.GCONFIG_RECORD_LOG_DESENSITIZE, "请求记录是否进行脱敏处理（1开启脱敏 0关闭脱敏）", "options", "0|关闭脱敏,1|开启脱敏", configMap)
 	updateConfigIntItem(initLoad, "system", "token_expire_time", global.GCONFIG_RECORD_TOKEN_EXPIRE_MINTUTES, "管理平台令牌有效期，单位分钟（默认5分钟）", "int", "", configMap)
 	updateConfigIntItem(initLoad, "system", "spider_deny", global.GCONFIG_RECORD_SPIDER_DENY, "爬虫禁止访问开关 默认 0 只检测不阻止访问 1 检测并阻止访问）", "int", "", configMap)
 	updateConfigIntItem(initLoad, "debug", "enable_debug", global.GCONFIG_RECORD_DEBUG_ENABLE, "调试开关 默认关闭", "int", "", configMap)


### PR DESCRIPTION
- Introduced GCONFIG_RECORD_LOG_DESENSITIZE to control desensitization of request logs.
- Updated task configuration to include desensitization option.
- Modified log handling to apply desensitization based on the new configuration.

#626