### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ SamWaf is continuously iterating. We welcome feedback and suggestions.
 
 ## Star history
 
-[![Star History Chart](https://api.star-history.com/svg?repos=samwafgo/samwaf&type=Date)](https://star-history.com/#samwafgo/samwaf&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=samwafgo/samwaf&type=Date)](https://star-history.dera.page/#samwafgo/samwaf&Date)
 
 
 #  License

--- a/README_ar.md
+++ b/README_ar.md
@@ -313,7 +313,7 @@ Linux: ./SamWafLinux64 start
 
 ## سجل النجوم
 
-[![مخطط سجل النجوم](https://api.star-history.com/svg?repos=samwafgo/samwaf&type=Date)](https://star-history.com/#samwafgo/samwaf&Date)
+[![مخطط سجل النجوم](https://star-history.dera.page/svg?repos=samwafgo/samwaf&type=Date)](https://star-history.dera.page/#samwafgo/samwaf&Date)
 
 
 #  الترخيص

--- a/README_bn.md
+++ b/README_bn.md
@@ -313,7 +313,7 @@ SamWaf ধারাবাহিকভাবে উন্নত হচ্ছে�
 
 ## স্টার হিস্টরি
 
-[![স্টার হিস্টরি চার্ট](https://api.star-history.com/svg?repos=samwafgo/samwaf&type=Date)](https://star-history.com/#samwafgo/samwaf&Date)
+[![স্টার হিস্টরি চার্ট](https://star-history.dera.page/svg?repos=samwafgo/samwaf&type=Date)](https://star-history.dera.page/#samwafgo/samwaf&Date)
 
 
 #  লাইসেন্স

--- a/README_cn.md
+++ b/README_cn.md
@@ -313,7 +313,7 @@ How to compile
 
 ## Star 历史趋势
 
-[![Star History Chart](https://api.star-history.com/svg?repos=samwafgo/samwaf&type=Date)](https://star-history.com/#samwafgo/samwaf&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=samwafgo/samwaf&type=Date)](https://star-history.dera.page/#samwafgo/samwaf&Date)
 
 # 许可证书
 SamWaf 采用 Apache 2.0 license. 详细见 [LICENSE](./LICENSE) .

--- a/README_de.md
+++ b/README_de.md
@@ -313,7 +313,7 @@ SamWaf wird kontinuierlich weiterentwickelt. Feedback und Vorschläge sind willk
 
 ## Star-Verlauf
 
-[![Star-History-Diagramm](https://api.star-history.com/svg?repos=samwafgo/samwaf&type=Date)](https://star-history.com/#samwafgo/samwaf&Date)
+[![Star-History-Diagramm](https://star-history.dera.page/svg?repos=samwafgo/samwaf&type=Date)](https://star-history.dera.page/#samwafgo/samwaf&Date)
 
 
 #  Lizenz

--- a/README_es.md
+++ b/README_es.md
@@ -313,7 +313,7 @@ SamWaf está en continua iteración. Agradecemos sus comentarios y sugerencias.
 
 ## Historial de estrellas
 
-[![Gráfico del historial de estrellas](https://api.star-history.com/svg?repos=samwafgo/samwaf&type=Date)](https://star-history.com/#samwafgo/samwaf&Date)
+[![Gráfico del historial de estrellas](https://star-history.dera.page/svg?repos=samwafgo/samwaf&type=Date)](https://star-history.dera.page/#samwafgo/samwaf&Date)
 
 
 #  Licencia

--- a/README_fr.md
+++ b/README_fr.md
@@ -313,7 +313,7 @@ SamWaf évolue en permanence. Vos retours et suggestions sont les bienvenus.
 
 ## Historique des stars
 
-[![Graphique de l'historique des stars](https://api.star-history.com/svg?repos=samwafgo/samwaf&type=Date)](https://star-history.com/#samwafgo/samwaf&Date)
+[![Graphique de l'historique des stars](https://star-history.dera.page/svg?repos=samwafgo/samwaf&type=Date)](https://star-history.dera.page/#samwafgo/samwaf&Date)
 
 
 #  Licence

--- a/README_hi.md
+++ b/README_hi.md
@@ -313,7 +313,7 @@ SamWaf में लगातार सुधार हो रहा है। �
 
 ## स्टार हिस्ट्री
 
-[![स्टार हिस्ट्री चार्ट](https://api.star-history.com/svg?repos=samwafgo/samwaf&type=Date)](https://star-history.com/#samwafgo/samwaf&Date)
+[![स्टार हिस्ट्री चार्ट](https://star-history.dera.page/svg?repos=samwafgo/samwaf&type=Date)](https://star-history.dera.page/#samwafgo/samwaf&Date)
 
 
 #  लाइसेंस

--- a/README_id.md
+++ b/README_id.md
@@ -313,7 +313,7 @@ SamWaf terus berkembang melalui iterasi. Kami menyambut baik umpan balik dan sar
 
 ## Riwayat Star
 
-[![Grafik Riwayat Star](https://api.star-history.com/svg?repos=samwafgo/samwaf&type=Date)](https://star-history.com/#samwafgo/samwaf&Date)
+[![Grafik Riwayat Star](https://star-history.dera.page/svg?repos=samwafgo/samwaf&type=Date)](https://star-history.dera.page/#samwafgo/samwaf&Date)
 
 
 #  Lisensi

--- a/README_ja.md
+++ b/README_ja.md
@@ -313,7 +313,7 @@ SamWaf は継続的に改善を続けています。フィードバックやご�
 
 ## Star 履歴
 
-[![Star History チャート](https://api.star-history.com/svg?repos=samwafgo/samwaf&type=Date)](https://star-history.com/#samwafgo/samwaf&Date)
+[![Star History チャート](https://star-history.dera.page/svg?repos=samwafgo/samwaf&type=Date)](https://star-history.dera.page/#samwafgo/samwaf&Date)
 
 
 #  ライセンス

--- a/README_ko.md
+++ b/README_ko.md
@@ -313,7 +313,7 @@ SamWaf는 지속적으로 발전하고 있습니다. 피드백과 제안을 환�
 
 ## Star 히스토리
 
-[![Star 히스토리 차트](https://api.star-history.com/svg?repos=samwafgo/samwaf&type=Date)](https://star-history.com/#samwafgo/samwaf&Date)
+[![Star 히스토리 차트](https://star-history.dera.page/svg?repos=samwafgo/samwaf&type=Date)](https://star-history.dera.page/#samwafgo/samwaf&Date)
 
 
 #  라이선스

--- a/README_pt.md
+++ b/README_pt.md
@@ -313,7 +313,7 @@ O SamWaf está em iteração contínua. Feedback e sugestões são bem-vindos.
 
 ## Histórico de Stars
 
-[![Gráfico de Histórico de Stars](https://api.star-history.com/svg?repos=samwafgo/samwaf&type=Date)](https://star-history.com/#samwafgo/samwaf&Date)
+[![Gráfico de Histórico de Stars](https://star-history.dera.page/svg?repos=samwafgo/samwaf&type=Date)](https://star-history.dera.page/#samwafgo/samwaf&Date)
 
 
 #  Licença

--- a/README_ru.md
+++ b/README_ru.md
@@ -313,7 +313,7 @@ SamWaf постоянно развивается. Мы будем рады ва�
 
 ## История звёзд
 
-[![График истории звёзд](https://api.star-history.com/svg?repos=samwafgo/samwaf&type=Date)](https://star-history.com/#samwafgo/samwaf&Date)
+[![График истории звёзд](https://star-history.dera.page/svg?repos=samwafgo/samwaf&type=Date)](https://star-history.dera.page/#samwafgo/samwaf&Date)
 
 
 #  Лицензия

--- a/README_ur.md
+++ b/README_ur.md
@@ -313,7 +313,7 @@ SamWaf مسلسل ارتقا پذیر ہے۔ ہم فیڈ بیک اور تجاو�
 
 ## اسٹار ہسٹری
 
-[![اسٹار ہسٹری چارٹ](https://api.star-history.com/svg?repos=samwafgo/samwaf&type=Date)](https://star-history.com/#samwafgo/samwaf&Date)
+[![اسٹار ہسٹری چارٹ](https://star-history.dera.page/svg?repos=samwafgo/samwaf&type=Date)](https://star-history.dera.page/#samwafgo/samwaf&Date)
 
 
 #  لائسنس


### PR DESCRIPTION
The star history chart in the READMEs was no longer rendering because the upstream chart depends on GitHub's stargazer API, which is now restricted. This change switches the chart to a working data source so the star history displays correctly again across the main and localized README files.